### PR TITLE
fix: correct file size is now given to mmap (posix_file_view)

### DIFF
--- a/include/vfs/posix_file_view.hpp
+++ b/include/vfs/posix_file_view.hpp
@@ -180,7 +180,8 @@ namespace vfs {
         {
             vfs_check(fileDescriptor_ != -1);
             struct stat st;
-            vfs_check(fstat(fileDescriptor_, &st) != -1);
+            const auto result = fstat(fileDescriptor_, &st);
+            vfs_check(result != -1);
             return st.st_size;
         }
 

--- a/include/vfs/posix_virtual_allocator.hpp
+++ b/include/vfs/posix_virtual_allocator.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/mman.h>
+
 
 namespace vfs {
 
@@ -20,7 +22,7 @@ namespace vfs {
             return mprotect(pAddr, size, PROT_READ | PROT_WRITE) == 0 ? pAddr : nullptr;
         }
         //------------------------------------------------------------------------------------------
-        bool deallocate(void *pAddr)
+        static bool deallocate(void *pAddr)
         {
             return munmap(pAddr, 0);
         }

--- a/tests/catch_amalgamated.cpp
+++ b/tests/catch_amalgamated.cpp
@@ -3777,7 +3777,7 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    static constexpr std::size_t sigStackSize = 32768;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },

--- a/tests/file_view_tests.hpp
+++ b/tests/file_view_tests.hpp
@@ -11,7 +11,8 @@ TEST_CASE("Fileview.", "[fileview]")
             {
                 // Read only 
                 {
-                    auto spFile = open_read_write(test_directory + "\\test\\fileview\\readonly\\test0.txt", vfs::file_creation_options::create_or_overwrite);
+                    auto spFile = open_read_write(test_directory + "\\test\\fileview\\readonly\\test0.txt",
+                                                  vfs::file_creation_options::create_or_overwrite);
                     spFile->resize(64 * 1024);
 
                     REQUIRE(vfs::file::exists(test_directory + "\\test\\fileview\\readonly\\test0.txt"));
@@ -19,7 +20,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::open_if_existing")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::open_if_existing);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"),
+                            vfs::file_creation_options::open_if_existing);
                     THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
@@ -29,7 +32,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::create_or_overwrite")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::create_or_overwrite);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"),
+                            vfs::file_creation_options::create_or_overwrite);
                     THEN("we should fail")
                     {
                         // This is expected behaviour. It does not make sense to open a read only view on a newly created file, or an overwritten file (which has also just been created). 
@@ -40,7 +45,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::open_or_create")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::open_or_create);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"),
+                            vfs::file_creation_options::open_or_create);
                     THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
@@ -50,7 +57,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::create_if_nonexisting")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::create_if_nonexisting);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"),
+                            vfs::file_creation_options::create_if_nonexisting);
                     THEN("we should fail")
                     {
                         // WE fail because we are trying to create a file that already exists.
@@ -64,7 +73,9 @@ TEST_CASE("Fileview.", "[fileview]")
             {
                 WHEN("we open a read_only_view with vfs::file::open_if_existing")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test1.txt"), vfs::file_creation_options::open_if_existing);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test1.txt"),
+                            vfs::file_creation_options::open_if_existing);
                     THEN("we should fail")
                     {
                         REQUIRE(spFileView == nullptr);
@@ -74,7 +85,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::create_or_overwrite")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test1.txt"), vfs::file_creation_options::create_or_overwrite);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test1.txt"),
+                            vfs::file_creation_options::create_or_overwrite);
                     THEN("we should fail")
                     {
                         // The creation of the file should succeed but the fileview will not be valid, since the file is empty and in read only.
@@ -86,7 +99,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::open_or_create")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test2.txt"), vfs::file_creation_options::open_or_create);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test2.txt"),
+                            vfs::file_creation_options::open_or_create);
                     THEN("we should fail")
                     {
                         // The creation of the file should succeed but the fileview will not be valid, since the file is empty and in read only.
@@ -98,7 +113,9 @@ TEST_CASE("Fileview.", "[fileview]")
 
                 WHEN("we open a read_only_view with vfs::file::create_if_nonexisting")
                 {
-                    auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test3.txt"), vfs::file_creation_options::create_if_nonexisting);
+                    auto spFileView = vfs::open_read_only_view(
+                            vfs::path(test_directory + "\\test\\fileview\\readonly\\test3.txt"),
+                            vfs::file_creation_options::create_if_nonexisting);
                     THEN("we should fail")
                     {
                         // The creation of the file should succeed but the fileview will not be valid, since the file is empty and in read only.

--- a/tests/file_view_tests.hpp
+++ b/tests/file_view_tests.hpp
@@ -7,7 +7,6 @@ TEST_CASE("Fileview.", "[fileview]")
         {
             vfs::create_path(test_directory + "\\test\\fileview\\readonly");
 
-            // TODO: have a better error for the following cases where we are supposed to fail.
             GIVEN("an existing file")
             {
                 // Read only 
@@ -21,7 +20,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::open_if_existing")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::open_if_existing);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -31,7 +30,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::create_or_overwrite")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::create_or_overwrite);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // This is expected behaviour. It does not make sense to open a read only view on a newly created file, or an overwritten file (which has also just been created). 
                         REQUIRE(spFileView != nullptr);
@@ -42,7 +41,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::open_or_create")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::open_or_create);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -52,7 +51,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::create_if_nonexisting")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test0.txt"), vfs::file_creation_options::create_if_nonexisting);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // WE fail because we are trying to create a file that already exists.
                         REQUIRE(spFileView == nullptr);
@@ -66,7 +65,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::open_if_existing")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test1.txt"), vfs::file_creation_options::open_if_existing);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         REQUIRE(spFileView == nullptr);
                         REQUIRE(!vfs::file::exists(test_directory + "\\test\\fileview\\readonly\\test1.txt"));
@@ -76,7 +75,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::create_or_overwrite")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test1.txt"), vfs::file_creation_options::create_or_overwrite);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // The creation of the file should succeed but the fileview will not be valid, since the file is empty and in read only.
                         REQUIRE(spFileView != nullptr);
@@ -88,7 +87,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::open_or_create")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test2.txt"), vfs::file_creation_options::open_or_create);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // The creation of the file should succeed but the fileview will not be valid, since the file is empty and in read only.
                         REQUIRE(spFileView != nullptr);
@@ -100,7 +99,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_only_view with vfs::file::create_if_nonexisting")
                 {
                     auto spFileView = vfs::open_read_only_view(vfs::path(test_directory + "\\test\\fileview\\readonly\\test3.txt"), vfs::file_creation_options::create_if_nonexisting);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // The creation of the file should succeed but the fileview will not be valid, since the file is empty and in read only.
                         REQUIRE(spFileView != nullptr);
@@ -129,7 +128,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::open_if_existing")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test0.txt"), vfs::file_creation_options::open_if_existing);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -139,7 +138,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::create_or_overwrite")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test0.txt"), vfs::file_creation_options::create_or_overwrite);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // This is expected behaviour. It does not make sense to open a read write view on a newly created file, or an overwritten file (which has also just been created). 
                         REQUIRE(spFileView != nullptr);
@@ -150,7 +149,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::open_or_create")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test0.txt"), vfs::file_creation_options::open_or_create);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -160,7 +159,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::create_if_nonexisting")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test0.txt"), vfs::file_creation_options::create_if_nonexisting);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         // We can't open an existing file with create_if_nonexisting.
                         REQUIRE(spFileView == nullptr);
@@ -174,7 +173,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::open_if_existing with viewSize")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test1.txt"), vfs::file_creation_options::open_if_existing, vfs::file_flags::none, vfs::file_attributes::normal, viewSize);
-                    THEN("we fail")
+                    THEN("we should fail")
                     {
                         REQUIRE(spFileView == nullptr);
                         REQUIRE(!vfs::file::exists(test_directory + "\\test\\fileview\\readwrite\\test1.txt"));
@@ -184,7 +183,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::create_or_overwrite with viewSize")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test1.txt"), vfs::file_creation_options::create_or_overwrite, vfs::file_flags::none, vfs::file_attributes::normal, viewSize);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -195,7 +194,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::open_or_create with viewSize")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test2.txt"), vfs::file_creation_options::open_or_create, vfs::file_flags::none, vfs::file_attributes::normal, viewSize);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -206,7 +205,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 WHEN("we open a read_write_view with vfs::file::create_if_nonexisting with viewSize")
                 {
                     auto spFileView = vfs::open_read_write_view(vfs::path(test_directory + "\\test\\fileview\\readwrite\\test3.txt"), vfs::file_creation_options::create_if_nonexisting, vfs::file_flags::none, vfs::file_attributes::normal, viewSize);
-                    THEN("we succeed")
+                    THEN("we should succeed")
                     {
                         REQUIRE(spFileView != nullptr);
                         REQUIRE(spFileView->isValid());
@@ -229,7 +228,7 @@ TEST_CASE("Fileview.", "[fileview]")
             {
                 // access violation writing location.
                 auto bytesWritten = spFileView->write(text);
-                THEN("we succeed")
+                THEN("we should succeed")
                 {
                     REQUIRE(bytesWritten == text.size());
                 }
@@ -241,7 +240,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 v.resize(text.size());
                 auto bytesRead = spFileView->read(v);
 
-                THEN("we succeed")
+                THEN("we should succeed")
                 {
                     REQUIRE(bytesRead == text.size());
                 }
@@ -261,7 +260,7 @@ TEST_CASE("Fileview.", "[fileview]")
                 v.resize(text.size());
                 auto bytesRead = spFileView->read(v);
 
-                THEN("we succeed")
+                THEN("we should succeed")
                 {
                     REQUIRE(bytesRead == text.size());
                 }


### PR DESCRIPTION
fix: In release builds fstat is now called (vfs_check is deactivated in release). correct size is given to mmap.
Some small fixes in posix_virtual_allocator.

fix: fixed compiling error, MINSIGSTKSZ is no longer a compile time value. (catch_amalgated.cpp)

style: more readable file_view tests, have a better message for cases that fail and succed