### PR TITLE
fix: posix_watcher fixes and watcher_tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ temp/
 projects/vs2017/.vs/
 bin/
 *.user
+.idea
+cmake-build*
+test
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,20 @@
 cmake_minimum_required(VERSION 3.12)
 
-# Set the project name
 project(vfs)
 
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_GLIBCXX_DEBUG")
 
-file(GLOB_RECURSE test_source_files CONFIGURE_DEPENDS "tests/*.cpp")
+add_executable(vfs_tests
+        tests/catch_amalgamated.cpp
+        tests/vfs_tests.cpp
+)
 
-include_directories(include)
-include_directories(include/vfs)
-
-add_compile_definitions(_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
-
-add_executable(vfs
-        ${test_source_files})
+target_include_directories(vfs_tests PRIVATE
+        include
+        include/vfs
+)
 
 # Link with lrt and pthread
 set(CMAKE_EXE_LINKER_FLAGS "-lrt -pthread")
-
-# This facilitates debugging in Clion (Posix).
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_GLIBCXX_DEBUG")

--- a/include/vfs/posix_file_view.hpp
+++ b/include/vfs/posix_file_view.hpp
@@ -25,7 +25,8 @@ namespace vfs {
 	protected:
 		//------------------------------------------------------------------------------------------
         posix_file_view(file_sptr spFile, int64_t viewSize)
-            : sharedMemory_(false)
+            : spFile_(spFile)
+            , sharedMemory_(false)
             , name_(spFile->fileName())
             , fileDescriptor_(spFile->nativeHandle())
             , pData_(nullptr)
@@ -39,7 +40,8 @@ namespace vfs {
 
         //------------------------------------------------------------------------------------------
         posix_file_view(const path &name, int64_t size, bool openExisting)
-            : sharedMemory_(true)
+            : spFile_(nullptr)
+            , sharedMemory_(true)
             , name_(name)
             , fileDescriptor_(-1)
             , pData_(nullptr)
@@ -301,8 +303,15 @@ namespace vfs {
             return false;
         }
 
+        //------------------------------------------------------------------------------------------
+        auto getFile() const
+        {
+            return spFile_;
+        }
+
 	private:
 		//------------------------------------------------------------------------------------------
+        file_sptr   spFile_;
         bool        sharedMemory_;
         path        name_;
         uint32_t    fileDescriptor_;

--- a/tests/watcher_tests.hpp
+++ b/tests/watcher_tests.hpp
@@ -1,69 +1,66 @@
 
 TEST_CASE("Watcher.", "[watcher]")
 {
-    auto filePath                   = std::string(test_directory + "\\test\\watcher");
-    auto filesDirectoriesWatched    = std::unordered_set<std::string>();
-    auto filesDirectoriesCreated    = std::unordered_set<std::string>();
+    const auto filePath                 = std::string(test_directory + "/test/watcher");
+    auto filesDirectoriesWatched        = std::unordered_set<std::string>();
+    auto filesDirectoriesCreated        = std::unordered_set<std::string>();
 
-    auto numFilesToCreate       = 5;
-    auto numDirectoriesToCreate = 3;
+    const auto numFilesToCreate         = 5;
+    const auto numDirectoriesToCreate   = 3;
 
-    vfs::directory::create_directory(filePath);
+    vfs::create_path(filePath);
 
     // TODO. test for watching only files or folders.
     SECTION("we can watch over the files and folders of a directory")
     {
         auto watcher = vfs::watcher(filePath, [&filesDirectoriesWatched](const vfs::path &newDir)
-            {
-                std::error_code err{};
-                if (std::filesystem::exists(newDir.str()) && !std::filesystem::is_empty(newDir.str(), err))
-                {
-                    // This callback could be called when the folder is empty since callback is called in watcher::run() before waiting for the event.
-                    // Using directory_iterator with an empty directory cause program to crash.
-                    for (const auto &entry : std::filesystem::directory_iterator(newDir.str()))
-                    {
-                        filesDirectoriesWatched.insert(entry.path().filename().string());
-                    }
-                }
-            });
-
-        watcher.startWatching(true, true);
-        
-        GIVEN("the creation of files and directories in a watched directory")
         {
-            // Start creating files and directories.
-            for (auto i = 0; i < numFilesToCreate; ++i)
+            std::error_code err{};
+            if (std::filesystem::exists(newDir.str()) && !std::filesystem::is_empty(newDir.str(), err))
             {
-                auto fileName = "test" + std::to_string(i) + ".txt";
-                vfs::open_read_only(vfs::path(filePath + "\\" + fileName), vfs::file_creation_options::create_or_overwrite);
-                filesDirectoriesCreated.insert(fileName);
-
-            }
-            for (auto i = 0; i < numDirectoriesToCreate; ++i)
-            {
-                auto dirName = "dir" + std::to_string(i);
-                vfs::directory::create_directory(filePath + "\\" + dirName);
-                filesDirectoriesCreated.insert(dirName);
-            }
-
-            // Sleep for a bit to wait for watcher.
-            using namespace std::chrono_literals;
-            std::this_thread::sleep_for(500ms);
-
-            THEN("the watcher will watch all of them!")
-            {
-                auto isValid = true;
-                for (auto &fileDirCreated : filesDirectoriesCreated)
+                // This callback could be called when the folder is empty since callback is called in watcher::run() before waiting for the event.
+                // Using directory_iterator with an empty directory cause program to crash.
+                for (const auto &entry : std::filesystem::directory_iterator(newDir.str()))
                 {
-                    if (filesDirectoriesWatched.find(fileDirCreated) == filesDirectoriesWatched.end())
-                    {
-                        vfs_errorf("%s was not caught by the watcher", fileDirCreated.c_str());
-                        isValid = false;
-                    }
+                    const auto watchedFileDir = entry.path().filename().string();
+                    filesDirectoriesWatched.insert(watchedFileDir);
                 }
+            }
+        });
 
-                REQUIRE(isValid);
+        REQUIRE(watcher.startWatching(true, true));
+
+        // Sleep for a bit so that watcher doesn't call the callback before watching the files.
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(500ms);
+
+        // Start creating files and directories.
+        for (auto i = 0; i < numFilesToCreate; ++i)
+        {
+            auto fileName = "test" + std::to_string(i) + ".txt";
+            vfs::open_read_only(vfs::path(filePath + "/" + fileName), vfs::file_creation_options::create_or_overwrite);
+            filesDirectoriesCreated.insert(fileName);
+        }
+        for (auto i = 0; i < numDirectoriesToCreate; ++i)
+        {
+            auto dirName = "dir" + std::to_string(i);
+            vfs::create_path(filePath + "/" + dirName);
+            filesDirectoriesCreated.insert(dirName);
+        }
+
+        // Sleep for a bit to wait for watcher to watch files and call callback.
+        std::this_thread::sleep_for(500ms);
+
+        auto isValid = true;
+        for (auto &fileDirCreated : filesDirectoriesCreated)
+        {
+            if (filesDirectoriesWatched.find(fileDirCreated) == filesDirectoriesWatched.end())
+            {
+                vfs_errorf("%s was not caught by the watcher", fileDirCreated.c_str());
+                isValid = false;
             }
         }
+
+        REQUIRE(isValid);
     }
 }


### PR DESCRIPTION
posix_watcher : Added ctor that takes waitTimeoutInMs and wakeUp() function kill thread with SIGUSR1 instead of SIGINT, since SIGINT can cause process wide repercussions. Previously nothing was being watched but fixed with the use of the eventBuffer.

posix_file_view: Added getFile() which is specified in the interface

watcher_tests: made them actually function on Posix/Windows

etc: cleaned up CMakeLists.txt and added CLion/VS studio specific directories to ignore